### PR TITLE
argparse scan option

### DIFF
--- a/aranet4/aranetctl.py
+++ b/aranet4/aranetctl.py
@@ -143,6 +143,15 @@ def print_records(records):
     print("-" * char_repeat)
 
 
+def print_scan_result(device, ad_data):
+    if "Aranet4" in device.name:
+        print("Aranet4 device found")
+        print("----------------------------")
+        print(f"  Name:    {device.name}")
+        print(f"  Address: {device.address}")
+        print()
+
+
 def write_csv(filename, log_data):
     """
     Output `client.Record` dataclass to csv file
@@ -198,28 +207,25 @@ def wait_for_new_record(address):
         sleep(1)
         print(f"Next data point in {secs}...", end="\r")
 
+
 async def scan_devices():
     devices = []
     discovered = await BleakScanner.discover()
     for d in discovered:
         if ("Aranet4" in d.name):
             devices.append(d)
+            print(type(d))
     return devices
 
+
 def main(argv):
-    # Workaround for required device address
-    if ("--scan" in argv):
-        print("Looking for Aranet4 devices...")
-        devices = asyncio.run(scan_devices())
-        print("{} Aranet4 device(s) found".format(len(devices)))
-        for d in devices:
-            print("----------------------------")
-            print("  Name:    {}".format(d.name))
-            print("  Address: {}".format(d.address))
-        print()
+    args = parse_args(argv)
+
+    if args.scan:
+        devices = client.find_nearby(print_scan_result)
+        print("Scan result:", devices)
         return
 
-    args = parse_args(argv)
     if args.records:
         if args.wait:
             wait_for_new_record(args.device_mac)

--- a/aranet4/aranetctl.py
+++ b/aranet4/aranetctl.py
@@ -208,16 +208,6 @@ def wait_for_new_record(address):
         print(f"Next data point in {secs}...", end="\r")
 
 
-async def scan_devices():
-    devices = []
-    discovered = await BleakScanner.discover()
-    for d in discovered:
-        if ("Aranet4" in d.name):
-            devices.append(d)
-            print(type(d))
-    return devices
-
-
 def main(argv):
     args = parse_args(argv)
 

--- a/aranet4/aranetctl.py
+++ b/aranet4/aranetctl.py
@@ -1,13 +1,10 @@
 import argparse
 import csv
-import json
 from dataclasses import asdict
 import datetime
 from pathlib import Path
 import sys
 from time import sleep
-import asyncio
-from bleak import BleakScanner
 
 import requests
 

--- a/aranet4/aranetctl.py
+++ b/aranet4/aranetctl.py
@@ -31,16 +31,16 @@ format_str = """
 
 def parse_args(ctl_args):
     parser = argparse.ArgumentParser()
-    parser.add_argument("device_mac", help="Aranet4 Bluetooth Address")
+    parser.add_argument("device_mac", nargs='?', help="Aranet4 Bluetooth Address")
+    parser.add_argument(
+        "--scan", action="store_true", help="Scan Aranet4 devices"
+    )
     current = parser.add_argument_group("Options for current reading")
     current.add_argument(
         "-u", "--url", metavar="URL", help="Remote url for current value push"
     )
     parser.add_argument(
         "-r", "--records", action="store_true", help="Fetch historical log records"
-    )
-    parser.add_argument(
-        "--scan", action="store_true", help="Scan Aranet4 devices"
     )
     history = parser.add_argument_group("Filter History Log Records")
     history.add_argument(
@@ -223,7 +223,7 @@ def main(argv):
 
     if args.scan:
         devices = client.find_nearby(print_scan_result)
-        print("Scan result:", devices)
+        print(f"Scan finished. Found {len(devices)}")
         return
 
     if args.records:

--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -7,6 +7,8 @@ import struct
 from typing import List
 
 from bleak import BleakClient
+from bleak import BleakScanner
+from bleak.backends.device import BLEDevice
 
 
 class Aranet4Error(Exception):
@@ -372,6 +374,23 @@ async def _current_reading(address):
 def get_current_readings(mac_address: str) -> CurrentReading:
     """Get from the device the current measurements"""
     return asyncio.run(_current_reading(mac_address))
+
+
+async def _find_nearby(detection_callback: callable,
+                       duration: int = 20) -> List[BLEDevice]:
+    scanner = BleakScanner()
+    scanner.register_detection_callback(detection_callback)
+    print("Looking for Aranet4 devices...")
+    await scanner.start()
+    await asyncio.sleep(duration)
+    await scanner.stop()
+    return [device
+            for device in scanner.discovered_devices
+            if "Aranet4" in device.name]
+
+
+def find_nearby(detect_callback: callable) -> List[BLEDevice]:
+    return asyncio.run(_find_nearby(detect_callback))
 
 
 async def _all_records(address, entry_filter):

--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -377,7 +377,7 @@ def get_current_readings(mac_address: str) -> CurrentReading:
 
 
 async def _find_nearby(detection_callback: callable,
-                       duration: int = 20) -> List[BLEDevice]:
+                       duration: int = 5) -> List[BLEDevice]:
     scanner = BleakScanner()
     scanner.register_detection_callback(detection_callback)
     print("Looking for Aranet4 devices...")

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -42,6 +42,7 @@ base_args = dict(
     last=None,
     output=None,
     records=False,
+    scan=False,
     start=None,
     url=None,
     wait=False,


### PR DESCRIPTION
- Changed argparse settings so that "--scan" can be specified on its own without requiring "device_mac" argument
- moved scan functionality into "client" rather than "aranetctl"
- Output found device as soon as it's found not wait until scan is complete
- Add "scan" argparse argument into tests
- Remove unused imports from aranetctl