### PR TITLE
Fix off-by-one errors when deciding history window

### DIFF
--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -418,19 +418,19 @@ def _calc_start_end(datapoint_times: int, entry_filter):
     if filter_start:
         time_start = -1
         for idx, timestamp in enumerate(datapoint_times, start=1):
-            if filter_start < timestamp:
+            if filter_start <= timestamp:
                 time_start = idx
                 break
-        if 0 < time_start < end:
+        if 0 < time_start <= end:
             start = time_start
     if filter_end:
         time_end = -1
         for idx, timestamp in enumerate(datapoint_times, start=1):
-            if timestamp < filter_end:
+            if timestamp <= filter_end:
                 time_end = idx
             else:
                 break
-        if start < time_end < end:
+        if start <= time_end <= end:
             end = time_end
     return start, end
 


### PR DESCRIPTION
When historical records are being retrieved, if a provided start or end timestamp happens to fall precisely on a measurement, the index calculation would fail and that filter would be ignored. This fixes that.