### PR TITLE
Properly handle systems with non-UTC timezones

### DIFF
--- a/aranet4/aranetctl.py
+++ b/aranet4/aranetctl.py
@@ -178,7 +178,7 @@ def write_csv(filename, log_data):
 
 def post_data(url, current):
     # get current measurement minute
-    now = datetime.datetime.utcnow().replace(microsecond=0)
+    now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
     delta_ago = datetime.timedelta(seconds=current.ago)
     t = now - delta_ago
     t = t.replace(second=0)  # epoch, floored to minutes

--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -284,7 +284,7 @@ class Aranet4:
     async def get_last_measurement_date(self, use_epoch: bool = False):
         """Calculate the time the last datapoint was logged"""
         ago = await self.get_seconds_since_update()
-        now = datetime.datetime.utcnow().replace(microsecond=0)
+        now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
         delta_ago = datetime.timedelta(seconds=ago)
         last_reading = now - delta_ago
         if use_epoch:
@@ -488,7 +488,7 @@ async def _all_records(address, entry_filter):
     dev_name = await monitor.get_name()
     dev_version = await monitor.get_version()
     last_log = await monitor.get_seconds_since_update()
-    now = datetime.datetime.utcnow().replace(microsecond=0)
+    now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
     interval = await monitor.get_interval()
     next_log = interval - last_log
     # Decide if there is enough time to read all the data
@@ -499,7 +499,7 @@ async def _all_records(address, entry_filter):
         await asyncio.sleep(next_log)
         # there was another log so update the numbers
         last_log = await monitor.get_seconds_since_update()
-        now = datetime.datetime.utcnow().replace(microsecond=0)
+        now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
 
     log_size = await monitor.get_total_readings()
     log_points = _log_times(now, log_size, interval, last_log)

--- a/examples/influx/influx.py
+++ b/examples/influx/influx.py
@@ -57,7 +57,7 @@ def main(argv):
         print("Fetching current readings...")
         current = aranet4.client.get_current_readings()
 
-        now = datetime.datetime.utcnow().replace(microsecond=0)
+        now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
         delta_ago = datetime.timedelta(seconds=current.ago)
         t = now - delta_ago
         t = t.replace(second=0)  # epoch, floored to minutes

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -96,7 +96,7 @@ class DataManipulation(unittest.TestCase):
         self.assertDictEqual(expected, args.__dict__)
 
     def test_calc_log_last_n(self):
-        mock_points = [datetime.datetime.utcnow()] * 200
+        mock_points = [datetime.datetime.now(datetime.timezone.utc)] * 200
         start, end = client._calc_start_end(mock_points, {'last': 20})
         # Requested numbers are inclusive so difference is 19 although
         # 20 data points have been requested


### PR DESCRIPTION
[The documentation for `datetime.utcnow()`][docs] states:

> Because naive `datetime` objects are treated by many `datetime` methods as local times, it is preferred to use aware datetimes to represent times in UTC. As such, the recommended way to create an object representing the current time in UTC is by calling `datetime.now(timezone.utc)`.

Accordingly, this updates the code to use timezone-aware `datetime` objects.

[docs]: https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow