### PR TITLE
Allow Aranet4Advertisement to parse advertisement data

### DIFF
--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -133,7 +133,7 @@ class CurrentReading:
         return value * multiplier
 
 
-@dataclass
+@dataclass(order=True)
 class Version:
     major: int = -1
     minor: int = -1


### PR DESCRIPTION
This refactors out the actual data handling to the Aranet4Advertisement class so clients can reuse this logic without completely using the Aranet4Scanner class. (This will be useful in wrapping this library where scanning is provided elsewhere, like in Home Assistant.)

Also removes unused has_service variable that was not accessible, and allows Version to be compared.