### PR TITLE
Fix errant exception thrown when device.name is NoneType

### DIFF
--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -247,7 +247,7 @@ class Aranet4Advertisement:
                 # Basic info
                 value_fmt = "<BBBB"
                 b0 = 255
-                if device.name.startswith("Aranet2"):
+                if device.name is not None and device.name.startswith("Aranet2"):
                     value = struct.unpack(value_fmt, raw_bytes[1:5])
                     b0 = raw_bytes[1]
                 else:


### PR DESCRIPTION
This resolves a quick exception getting thrown, observed in Home Assistant, where it would try to access ".startswith()" on a NoneType. This adds an extra check to device.name in client.py to verify if device.name is not None and then do the name check.