### PR TITLE
Improve scanner_simple.py

### DIFF
--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -146,14 +146,14 @@ class CurrentReading:
             ret += f"  Pressure:       {self.pressure:.01f} hPa\n"
             ret += f"  Battery:        {self.battery} %\n"
             ret += f"  Status Display: {self.status.name}\n"
-            ret += f"  Age:            {self.ago}/{self.interval}\n"
+            ret += f"  Age:            {self.ago}/{self.interval} s\n"
         elif self.type == AranetType.ARANET2:
             ret += f"  Temperature:    {self.temperature:.01f} \u00b0C\n"
             ret += f"  Humidity:       {self.humidity} %\n"
             ret += f"  Battery:        {self.battery} %\n"
             ret += f"  Status Temp.:   {self.status_t.name}\n"
             ret += f"  Status Humid.:  {self.status_h.name}\n"
-            ret += f"  Age:            {self.ago}/{self.interval}\n"
+            ret += f"  Age:            {self.ago}/{self.interval} s\n"
         elif self.type == AranetType.ARANET_RADIATION:
             m = math.floor(self.radiation_duration / 60 % 60)
             h = math.floor(self.radiation_duration / 3600 % 24)
@@ -166,7 +166,7 @@ class CurrentReading:
             ret += f"  Dose rate:      {self.radiation_rate/1000:.02f} uSv/h\n"
             ret += f"  Dose total:     {self.radiation_total/1000000:.04f} mSv/{dose_duration}\n"
             ret += f"  Battery:        {self.battery} %\n"
-            ret += f"  Age:            {self.ago}/{self.interval}\n"
+            ret += f"  Age:            {self.ago}/{self.interval} s\n"
         elif self.type == AranetType.ARANET_RADON:
             ret += f"  Radon Conc.:    {self.radon_concentration} Bq/m3\n"
             ret += f"  Temperature:    {self.temperature:.01f} \u00b0C\n"
@@ -174,7 +174,7 @@ class CurrentReading:
             ret += f"  Pressure:       {self.pressure:.01f} hPa\n"
             ret += f"  Battery:        {self.battery} %\n"
             ret += f"  Status Display: {self.status.name}\n"
-            ret += f"  Age:            {self.ago}/{self.interval}\n"
+            ret += f"  Age:            {self.ago}/{self.interval} s\n"
 
         else:
             ret += f"  Unknown device type\n"
@@ -1072,7 +1072,7 @@ async def _find_nearby(detect_callback: callable, duration: int) -> List[BLEDevi
 def find_nearby(detect_callback: callable, duration: int = 5) -> List[BLEDevice]:
     """
     Scans for nearby Aranet4 devices.
-    Will call callback on every valid Aranet4 advertisement, including duplcates
+    Will call callback on every valid Aranet4 advertisement, including duplicates
     """
 
     return asyncio.run(_find_nearby(detect_callback, duration))

--- a/examples/scanner/scanner_simple.py
+++ b/examples/scanner/scanner_simple.py
@@ -22,7 +22,7 @@ def print_advertisement(advertisement):
         # print(f"  Calibration state: {mf_data.calibration_state.name}")
         # print(f"  DFU Active:        {mf_data.dfu_active:}")
 
-    print(f"  RSSI:              {advertisement.device.rssi} dBm")
+    print(f"  RSSI:              {advertisement.rssi} dBm")
 
     if advertisement.readings:
         readings = advertisement.readings
@@ -31,7 +31,7 @@ def print_advertisement(advertisement):
         print(f"  Temperature:   {readings.temperature:.01f} \u00b0C")
         print(f"  Humidity:      {readings.humidity} %")
         print(f"  Pressure:      {readings.pressure:.01f} hPa")
-        print(f"  Battery:       {readings.battery} &")
+        print(f"  Battery:       {readings.battery} %")
         print(f"  Status disp.:  {readings.status.name}")
         print(f"  Ago:           {readings.ago} s")
     print()
@@ -40,7 +40,7 @@ def print_advertisement(advertisement):
 def main(argv):
     # Scan for 10 seconds, then print results
     print("Scanning Aranet4 devices...")
-    aranet4.client.find_nearby(on_scan, 5)
+    aranet4.client.find_nearby(on_scan, 10)
     print(f"\nFound {len(scanned_devices)} devices:\n")
 
     for addr in scanned_devices:

--- a/examples/scanner/scanner_simple.py
+++ b/examples/scanner/scanner_simple.py
@@ -5,45 +5,47 @@ scanned_devices = {}
 
 def on_scan(advertisement):
     if advertisement.device.address not in scanned_devices:
-        print(f"Found new device:  {advertisement.device.name}")
+        print(f"Found device:  {advertisement.device.name}")
 
     scanned_devices[advertisement.device.address] = advertisement
 
 def print_advertisement(advertisement):
     print("=======================================")
-    print(f"  Name:              {advertisement.device.name}")
-    print(f"  Address:           {advertisement.device.address}")
+    print(f"  Name:         {advertisement.device.name}")
+    print(f"  Address:      {advertisement.device.address}")
 
     if advertisement.manufacturer_data:
         mf_data = advertisement.manufacturer_data
-        print(f"  Version:           {mf_data.version}")
-        print(f"  Integrations:      {mf_data.integrations}")
-        # print(f"  Disconnected:      {mf_data.disconnected}")
-        # print(f"  Calibration state: {mf_data.calibration_state.name}")
-        # print(f"  DFU Active:        {mf_data.dfu_active:}")
+        print(f"  Version:      {mf_data.version}")
+        print(f"  Integrations: {mf_data.integrations}")
+        # print(f"  Disconnected: {mf_data.disconnected}")
+        # print(f"  Calibration:  {mf_data.calibration_state.name}")
+        # print(f"  DFU Active:   {mf_data.dfu_active:}")
 
-    print(f"  RSSI:              {advertisement.rssi} dBm")
+    print(f"  RSSI:         {advertisement.rssi} dBm")
 
     if advertisement.readings:
         readings = advertisement.readings
-        print("-------------------------------------")
-        print(f"  CO2:           {readings.co2} pm")
-        print(f"  Temperature:   {readings.temperature:.01f} \u00b0C")
-        print(f"  Humidity:      {readings.humidity} %")
-        print(f"  Pressure:      {readings.pressure:.01f} hPa")
-        print(f"  Battery:       {readings.battery} %")
-        print(f"  Status disp.:  {readings.status.name}")
-        print(f"  Ago:           {readings.ago} s")
+        print("---------------------------------------")
+        print(f"  CO2:            {readings.co2} pm")
+        print(f"  Temperature:    {readings.temperature:.01f} \u00b0C")
+        print(f"  Humidity:       {readings.humidity} %")
+        print(f"  Pressure:       {readings.pressure:.01f} hPa")
+        print(f"  Battery:        {readings.battery} %")
+        print(f"  Status Display: {readings.status.name}")
+        print(f"  Age:            {readings.ago}/{readings.interval} s")
     print()
 
 
 def main(argv):
     # Scan for 10 seconds, then print results
-    print("Scanning Aranet4 devices...")
+    print("Looking for Aranet devices...")
+    print()
     aranet4.client.find_nearby(on_scan, 10)
-    print(f"\nFound {len(scanned_devices)} devices:\n")
+    print(f"\nFound {len(scanned_devices)} devices:")
 
     for addr in scanned_devices:
+        print()
         advertisement = scanned_devices[addr]
         print_advertisement(advertisement)
 


### PR DESCRIPTION
- `BLEDevice.rssi` is deprecated since version 0.19.0 (see https://bleak.readthedocs.io/en/latest/api/index.html#bleak.backends.device.BLEDevice.rssi) switched to using the advertisement rssi (see https://bleak.readthedocs.io/en/latest/api/scanner.html#bleak.BleakScanner.discover).
- Comment states scan runs for 10 seconds but it actually runs for 5, corrected to run for 10 as it is not detecting Aranet4 in my environment at only 5 seconds.
- Battery has a "&" symbol after it instead of a percentage symbol (typo)?.