### PR TITLE
Add property `model` to `AranetType()` for use in Home Assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ dist/
 sdist/
 *.egg-info/
 *.egg
+
+# DEV
+build/
+.venv/

--- a/aranet4/__init__.py
+++ b/aranet4/__init__.py
@@ -1,4 +1,4 @@
 from aranet4.client import Aranet4, Aranet4HistoryDelegate, Aranet4Error, Aranet4Scanner
 
 name = "aranet4"
-__version__ = "2.5.0"
+__version__ = "2.4.0"

--- a/aranet4/__init__.py
+++ b/aranet4/__init__.py
@@ -1,4 +1,4 @@
 from aranet4.client import Aranet4, Aranet4HistoryDelegate, Aranet4Error, Aranet4Scanner
 
 name = "aranet4"
-__version__ = "2.4.0"
+__version__ = "2.5.0"

--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -57,7 +57,7 @@ class AranetType(IntEnum):
     UNKNOWN = 255
 
     @property
-    def manufacturer_name(self):
+    def model(self):
         description = {
             AranetType.ARANET4: "Aranet4 HOME",
             AranetType.ARANET2: "Aranet2 HOME",

--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -49,11 +49,23 @@ class Status(IntEnum):
 
 class AranetType(IntEnum):
     """Enum for the different Aranet devices"""
+    
     ARANET4 = 0
     ARANET2 = 1
     ARANET_RADIATION = 2
     ARANET_RADON = 3
     UNKNOWN = 255
+
+    @property
+    def manufacturer_name(self):
+        description = {
+            AranetType.ARANET4: "Aranet4 HOME",
+            AranetType.ARANET2: "Aranet2 HOME",
+            AranetType.ARANET_RADIATION: "Aranet Radiation",
+            AranetType.ARANET_RADON: "Aranet Radon Plus",
+            AranetType.UNKNOWN: "Unknown Aranet Device"
+        }
+        return description.get(self, "Unknown Aranet Device")
 
 @dataclass
 class Aranet4HistoryDelegate:

--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -59,8 +59,8 @@ class AranetType(IntEnum):
     @property
     def model(self):
         description = {
-            AranetType.ARANET4: "Aranet4 HOME",
-            AranetType.ARANET2: "Aranet2 HOME",
+            AranetType.ARANET4: "Aranet4",
+            AranetType.ARANET2: "Aranet2",
             AranetType.ARANET_RADIATION: "Aranet Radiation",
             AranetType.ARANET_RADON: "Aranet Radon Plus",
             AranetType.UNKNOWN: "Unknown Aranet Device"

--- a/examples/scanner/scanner_advanced.py
+++ b/examples/scanner/scanner_advanced.py
@@ -13,18 +13,19 @@ def on_scan(advertisement):
         return
 
     print("=======================================")
-    print(f"  Name:     {advertisement.device.name}")
-    print(f"  Address:  {advertisement.device.address}")
+    print(f"  Name:             {advertisement.device.name}")
+    print(f"  Model:            {advertisement.readings.type.model}")
+    print(f"  Address:          {advertisement.device.address}")
 
     if advertisement.manufacturer_data:
         mf_data = advertisement.manufacturer_data
-        print(f"  Version:           {mf_data.version}")
-        print(f"  Integrations:      {mf_data.integrations}")
+        print(f"  Version:          {mf_data.version}")
+        print(f"  Integrations:     {mf_data.integrations}")
         # print(f"  Disconnected:      {mf_data.disconnected}")
         # print(f"  Calibration state: {mf_data.calibration_state.name}")
         # print(f"  DFU Active:        {mf_data.dfu_active:}")
 
-    print(f"  RSSI:              {advertisement.rssi} dBm")
+    print(f"  RSSI:             {advertisement.rssi} dBm")
 
     if advertisement.readings:
         print("--------------------------------------")

--- a/examples/scanner/scanner_simple.py
+++ b/examples/scanner/scanner_simple.py
@@ -13,6 +13,7 @@ def on_scan(advertisement):
 def print_advertisement(advertisement):
     print("=======================================")
     print(f"  Name:         {advertisement.device.name}")
+    print(f"  Model:        {advertisement.readings.type.model}")
     print(f"  Address:      {advertisement.device.address}")
 
     if advertisement.manufacturer_data:
@@ -28,8 +29,6 @@ def print_advertisement(advertisement):
     if advertisement.readings:
         readings = advertisement.readings
         print("---------------------------------------")
-        print(f"  Type:           {readings.type} --> {readings.type.name}")
-        print(f"  Model:          {readings.type.model}")
         print(f"  CO2:            {readings.co2} pm")
         print(f"  Temperature:    {readings.temperature:.01f} \u00b0C")
         print(f"  Humidity:       {readings.humidity} %")

--- a/examples/scanner/scanner_simple.py
+++ b/examples/scanner/scanner_simple.py
@@ -29,7 +29,7 @@ def print_advertisement(advertisement):
         readings = advertisement.readings
         print("---------------------------------------")
         print(f"  Type:           {readings.type} --> {readings.type.name}")
-        print(f"  Model:          {readings.type.manufacturer_name}")
+        print(f"  Model:          {readings.type.model}")
         print(f"  CO2:            {readings.co2} pm")
         print(f"  Temperature:    {readings.temperature:.01f} \u00b0C")
         print(f"  Humidity:       {readings.humidity} %")

--- a/examples/scanner/scanner_simple.py
+++ b/examples/scanner/scanner_simple.py
@@ -28,6 +28,8 @@ def print_advertisement(advertisement):
     if advertisement.readings:
         readings = advertisement.readings
         print("---------------------------------------")
+        print(f"  Type:           {readings.type} --> {readings.type.name}")
+        print(f"  Model:          {readings.type.manufacturer_name}")
         print(f"  CO2:            {readings.co2} pm")
         print(f"  Temperature:    {readings.temperature:.01f} \u00b0C")
         print(f"  Humidity:       {readings.humidity} %")

--- a/tests/test_advertisements.py
+++ b/tests/test_advertisements.py
@@ -70,6 +70,7 @@ class DataManipulation(unittest.TestCase):
         self.assertEqual("v1.3.5", str(ad.manufacturer_data.version))
 
         self.assertEqual(AranetType.ARANET4, ad.readings.type)
+        self.assertEqual("Aranet4 HOME", ad.readings.type.model)
         self.assertEqual(1091, ad.readings.co2)
         self.assertEqual(20.8, ad.readings.temperature)
         self.assertEqual(53, ad.readings.humidity)
@@ -85,6 +86,7 @@ class DataManipulation(unittest.TestCase):
         self.assertEqual("v1.4.4", str(ad.manufacturer_data.version))
 
         self.assertEqual(AranetType.ARANET2, ad.readings.type)
+        self.assertEqual("Aranet2 HOME", ad.readings.type.model)
         self.assertEqual(20.5, ad.readings.temperature)
         self.assertEqual(52.2, ad.readings.humidity)
         self.assertEqual(59, ad.readings.battery)
@@ -98,6 +100,7 @@ class DataManipulation(unittest.TestCase):
         self.assertEqual("v1.4.38", str(ad.manufacturer_data.version))
 
         self.assertEqual(AranetType.ARANET_RADIATION, ad.readings.type)
+        self.assertEqual("Aranet Radiation", ad.readings.type.model)
         self.assertEqual(130, ad.readings.radiation_rate)
         self.assertEqual(13264, ad.readings.radiation_total)
         self.assertEqual(417900, ad.readings.radiation_duration)
@@ -112,6 +115,7 @@ class DataManipulation(unittest.TestCase):
         self.assertEqual("v1.6.4", str(ad.manufacturer_data.version))
 
         self.assertEqual(AranetType.ARANET_RADON, ad.readings.type)
+        self.assertEqual("Aranet Radon Plus", ad.readings.type.model)
         self.assertEqual(25.5, ad.readings.temperature)
         self.assertEqual(46.2, ad.readings.humidity)
         self.assertEqual(1018.5, ad.readings.pressure)


### PR DESCRIPTION
Hi there, first of all thank you for creating Aranet4-Python! 🚀 

I've extended `AranetType()` with the property `model` so it can be used in Home Assistant. I am working on a pull request over there: https://github.com/home-assistant/core/pull/134307. It was recommended, as this allows the device type to be displayed cleanly in the user interface.

~~I bumped the version to 2.5.0, as this extends functionality.~~

Let me know, if you have any suggestions!