### PR TITLE
Fix temperature bit shift

### DIFF
--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -257,15 +257,15 @@ class CurrentReading:
             self.temperature = self._set(Param.TEMPERATURE, value[4])
             self.humidity = self._set(Param.HUMIDITY2, value[5])
             self.battery = value[3]
-            self.status_humidity = Status(value[6] & 0b0011)
-            self.status_temperature = Status(value[6] & 0b1100)
+            self.status_humidity = Status(value[6] & 0b11)
+            self.status_temperature = Status(value[6] >> 2 & 0b11)
             self.interval = value[1]
             self.ago = value[2]
         else:
             self.temperature = self._set(Param.TEMPERATURE, value[1])
             self.humidity = self._set(Param.HUMIDITY2, value[3])
-            self.status_humidity = Status(value[6] & 0b0011)
-            self.status_temperature = Status(value[6] & 0b1100)
+            self.status_humidity = Status(value[6] & 0b11)
+            self.status_temperature = Status(value[6] >> 2 & 0b11)
             self.battery = value[5]
             self.interval = value[7]
             self.ago = value[8]


### PR DESCRIPTION
Fix temperature bit shift which introduced by https://github.com/Anrijs/Aranet4-Python/pull/52, when moving the parser to enum the status bits for temperature needs to be shifted right by two.

Fixes https://github.com/Anrijs/Aranet4-Python/issues/58