### PR TITLE
Pin Bleak version + update unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         "Operating System :: OS Independent"
     ],
     install_requires=[
-        "bleak==1.1.0",
+        "bleak==0.22.3",
         "requests"
     ],
     entry_points={

--- a/tests/test_advertisements.py
+++ b/tests/test_advertisements.py
@@ -1,7 +1,6 @@
 import unittest
 
 from bleak.backends.scanner import AdvertisementData
-from bleak.backends.device import BLEDevice
 from bleak import BleakClient
 
 from aranet4.client import Aranet4Advertisement
@@ -20,13 +19,8 @@ def fake_ad_data(name, service_uuid, manufacturer_data, address="00:11:22:33:44:
         platform_data=()
     )
 
-    # device = BleakClient(address)
-    #$ device.name = name
-    device = BLEDevice(
-        address=address,
-        name=name,
-        details={},
-    )
+    device = BleakClient(address)
+    device.name = name
 
     return {
         "ad_data": ad_data,


### PR DESCRIPTION
Seems like `pip3 install aranet4` installs older versions of `bleak` (e.g. `0.20.2`) if `pyaranet4` was previously installed/removed, which throws the following error when attempting to use the module.

```python3
Python 3.11.2 (main, Apr 28 2025, 14:11:48) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import aranet4
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/dist-packages/aranet4/__init__.py", line 1, in <module>
    from aranet4.client import Aranet4, Aranet4HistoryDelegate, Aranet4Error, Aranet4Scanner
  File "/usr/local/lib/python3.11/dist-packages/aranet4/client.py", line 13, in <module>
    from bleak.uuids import normalize_uuid_16
ImportError: cannot import name 'normalize_uuid_16' from 'bleak.uuids' (/usr/local/lib/python3.11/dist-packages/bleak/uuids.py)
```

`normalize_uuid_16()` was introduced in [bleak v0.21.0](https://github.com/hbldh/bleak/commit/48a1691f842c4431fb572260f4e45dadc6ef1da1)

This MR bumps that dependency to a v0.22.3 (latest minor semver on 0.x)