### PR TITLE
Fixed Aranet4 history returning 0 records in 2.6.0 (unknown model in _all_records)

### DIFF
--- a/aranet4/client.py
+++ b/aranet4/client.py
@@ -1122,6 +1122,39 @@ def find_nearby(detect_callback: callable, duration: int = 8) -> list[BLEDevice]
     return asyncio.run(_find_nearby(detect_callback, duration))
 
 
+def _apply_model_entry_filter(dev_name, entry_filter):
+    """
+    Adjust `entry_filter` in place for the device model detected from `dev_name`.
+    Returns True if the device model is not recognized.
+    """
+    if dev_name.startswith("Aranet2"):
+        entry_filter["pres"] = False
+        entry_filter["co2"] = False
+        if entry_filter.get("humi", False):
+            entry_filter["humi"] = 2  # v2 humidity
+    elif dev_name.startswith("Aranet\u2622"):
+        entry_filter["pres"] = False
+        entry_filter["co2"] = False
+        entry_filter["humi"] = False
+        entry_filter["temp"] = False
+        entry_filter["rad_dose"] = entry_filter.get("rad_dose", True)
+        entry_filter["rad_dose_rate"] = entry_filter.get("rad_dose_rate", True)
+        entry_filter["rad_dose_total"] = entry_filter.get("rad_dose_total", True)
+    elif dev_name.startswith("AranetRn"):
+        entry_filter["co2"] = False
+        entry_filter["radon_concentration"] = entry_filter.get("radon_concentration", True)
+        entry_filter["pres"] = entry_filter.get("pres", True)
+        if dev_name.startswith("AranetRn+"):
+            entry_filter["temp"] = entry_filter.get("temp", True)
+            if entry_filter.get("humi", False):
+                entry_filter["humi"] = 2  # v2 humidity
+    elif dev_name.startswith("Aranet4"):
+        pass  # default entry_filter (temp/humi/pres/co2) is correct for Aranet4
+    else:
+        return True
+    return False
+
+
 async def _all_records(address, entry_filter, remove_empty):
     """
     Get stored data points from device. Apply any filters requested
@@ -1155,31 +1188,7 @@ async def _all_records(address, entry_filter, remove_empty):
         last_log = await monitor.get_seconds_since_update()
         now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
 
-    unknwon_model = False
-
-    if dev_name.startswith("Aranet2"):
-        entry_filter["pres"] = False
-        entry_filter["co2"] = False
-        if entry_filter.get("humi", False):
-            entry_filter["humi"] = 2  # v2 humidity
-    elif dev_name.startswith("Aranet\u2622"):
-        entry_filter["pres"] = False
-        entry_filter["co2"] = False
-        entry_filter["humi"] = False
-        entry_filter["temp"] = False
-        entry_filter["rad_dose"] = entry_filter.get("rad_dose", True)
-        entry_filter["rad_dose_rate"] = entry_filter.get("rad_dose_rate", True)
-        entry_filter["rad_dose_total"] = entry_filter.get("rad_dose_total", True)
-    elif dev_name.startswith("AranetRn"):
-        entry_filter["co2"] = False
-        entry_filter["radon_concentration"] = entry_filter.get("radon_concentration", True)
-        entry_filter["pres"] = entry_filter.get("pres", True)
-        if dev_name.startswith("AranetRn+"):
-            entry_filter["temp"] = entry_filter.get("temp", True)
-            if entry_filter.get("humi", False):
-                entry_filter["humi"] = 2  # v2 humidity
-    else:
-        unknwon_model = True
+    unknwon_model = _apply_model_entry_filter(dev_name, entry_filter)
 
     log_size = await monitor.get_total_readings()
     log_points = _log_times(now, log_size, interval, last_log)

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -122,6 +122,23 @@ class DataManipulation(unittest.TestCase):
         times = client._log_times(now, log_records, log_interval, 20)
         self.assertListEqual(expected, times)
 
+    def test_model_entry_filter_aranet4(self):
+        # Regression test for #69: Aranet4 was treated as an unknown model,
+        # making get_all_records() return an empty Record
+        entry_filter = {"temp": True, "humi": True, "pres": True, "co2": True}
+        unknown = client._apply_model_entry_filter("Aranet4 12345", entry_filter)
+        self.assertFalse(unknown)
+        self.assertDictEqual(
+            {"temp": True, "humi": True, "pres": True, "co2": True}, entry_filter
+        )
+
+    def test_model_entry_filter_known_models(self):
+        for name in ["Aranet4 12345", "Aranet2 12345", "Aranet☢ 1", "AranetRn+ 1", "AranetRn1 1"]:
+            self.assertFalse(client._apply_model_entry_filter(name, {}), name)
+
+    def test_model_entry_filter_unknown_model(self):
+        self.assertTrue(client._apply_model_entry_filter("Foo", {}))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #69


## Root cause

Version 2.6.0 introduced per-model `entry_filter` adjustments in `_all_records()` via a device-name prefix chain with branches for Aranet2, Aranet Radiation, and Aranet Radon — but no branch for Aranet4. Aranet4 device names matched no branch, fell into the `else`, and were flagged as an unknown model, so `get_all_records()` returned an empty `Record` before issuing any history command.


## Fix

An explicit Aranet4 branch is added (a pass-through — the default filter of temp/humi/pres/co2 is already correct for Aranet4). The prefix chain is extracted into a private helper, `_apply_model_entry_filter()`, so the model detection can be unit-tested without hardware; behavior for all other models is unchanged and the public API is untouched. Regression tests are added asserting that names like `Aranet4 12345` are recognized while genuinely unknown names still short-circuit.

Other model-prefix chains were also checked: `_find_nearby()` (client.py line 468) already includes `"Aranet4"` in its prefix tuple, and the `CurrentReading`/advertisement paths key off `AranetType`, so `_all_records()` was the only spot with this bug.


## Before / after

Before (2.6.0, Aranet4 fw v2.0.7): `aranetctl <address> --records` reads name/version/interval/total-readings, then disconnects without writing a history command and prints an empty table, even with thousands of stored datapoints. 2.5.1 works correctly.

After (2.6.0 + this patch): history downloads as in 2.5.1.


## Verification

- `pytest` — 25 passed (including the new regression tests); flake8 (CI settings) clean.
- Verified against real hardware (Aranet4, firmware v2.0.7, macOS host): 2.5.1 works, 2.6.0 returns 0 records, 2.6.0 + this patch downloads history correctly.